### PR TITLE
Update to Current libesphttpd w/ Working cgiwifi

### DIFF
--- a/main/cgi-test.c
+++ b/main/cgi-test.c
@@ -28,7 +28,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiTestbed(HttpdConnData *connData) {
 	int l, x;
 	TestbedState *state=(TestbedState*)connData->cgiData;
 
-	if (connData->conn==NULL) {
+	if (connData->isConnectionClosed) {
 		//Connection aborted. Clean up.
 		if (state) free(state);
 		return HTTPD_CGI_DONE;
@@ -69,15 +69,15 @@ CgiStatus ICACHE_FLASH_ATTR cgiTestbed(HttpdConnData *connData) {
 		}
 	}
 	if (connData->requestType==HTTPD_METHOD_POST) {
-		if (connData->post->len!=connData->post->received) {
+		if (connData->post.len!=connData->post.received) {
 			//Still receiving data. Ignore this.
-			printf("Test: got %d/%d bytes\n", connData->post->received, connData->post->len);
+			printf("Test: got %d/%d bytes\n", connData->post.received, connData->post.len);
 			return HTTPD_CGI_MORE;
 		} else {
 			httpdStartResponse(connData, 200);
 			httpdHeader(connData, "content-type", "text/plain");
 			httpdEndHeaders(connData);
-			l=sprintf(buff, "%d", connData->post->received);
+			l=sprintf(buff, "%d", connData->post.received);
 			httpdSend(connData, buff, l);
 			return HTTPD_CGI_DONE;
 		}

--- a/main/cgi.c
+++ b/main/cgi.c
@@ -26,12 +26,12 @@ CgiStatus ICACHE_FLASH_ATTR cgiLed(HttpdConnData *connData) {
 	int len;
 	char buff[1024];
 
-	if (connData->conn==NULL) {
+	if (connData->isConnectionClosed) {
 		//Connection aborted. Clean up.
 		return HTTPD_CGI_DONE;
 	}
 
-	len=httpdFindArg(connData->post->buff, "led", buff, sizeof(buff));
+	len=httpdFindArg(connData->post.buff, "led", buff, sizeof(buff));
 	if (len!=0) {
 		currLedState=atoi(buff);
 		ioLed(currLedState);


### PR DESCRIPTION
 - update libesphttpd to version with denvera's ESP32 support in cgiwifi.c
 - update cgi.c and cgi-test.c to reflect changes in HttpdConnData struct
 - add neccessary instance and connection buffers to user_main.c
 - call wifiScanDoneCb() from user_main.c on SYSTEM_EVENT_SCAN_DONE event