### PR TITLE
resetBtn fix plus

### DIFF
--- a/html/led.tpl
+++ b/html/led.tpl
@@ -5,7 +5,7 @@
 <div id="main">
 <h1>The LED</h1>
 <p>
-If there's a LED connected to GPIO2, it's now %ledstate%. You can change that using the buttons below.
+If there's a LED connected to GPIO%ledgpio%, it's now %ledstate%. You can change that using the buttons below.
 </p>
 <form method="post" action="/led.cgi">
 <input type="submit" name="led" value="1">

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,14 @@
+menu "Example Configuration"
+	config EXAMPLE_WIFI_SSID
+		string "WiFi SSID"
+		default "myssid"
+		help
+		SSID (network name) for the example to connect to.
+
+	config EXAMPLE_WIFI_PASSWORD
+		string "WiFi Password"
+		default "mypassword"
+		help
+		WiFi password (WPA or WPA2) for the example to use.
+
+endmenu

--- a/main/cgi.c
+++ b/main/cgi.c
@@ -34,7 +34,7 @@ CgiStatus ICACHE_FLASH_ATTR cgiLed(HttpdConnData *connData) {
 	len=httpdFindArg(connData->post.buff, "led", buff, sizeof(buff));
 	if (len!=0) {
 		currLedState=atoi(buff);
-		ioLed(currLedState);
+		ioLed(LED_CGI, currLedState);
 	}
 
 	httpdRedirect(connData, "led.tpl");
@@ -55,6 +55,9 @@ CgiStatus ICACHE_FLASH_ATTR tplLed(HttpdConnData *connData, char *token, void **
 		} else {
 			strcpy(buff, "off");
 		}
+	}
+	if (strcmp(token, "ledgpio")==0) {
+		sprintf(buff, "%u", LED_CGI);
 	}
 	httpdSend(connData, buff, -1);
 	return HTTPD_CGI_DONE;

--- a/main/io.c
+++ b/main/io.c
@@ -1,4 +1,6 @@
 
+// io.c functions for status-LED and reset-button
+
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
@@ -8,53 +10,249 @@
  * ----------------------------------------------------------------------------
  */
 
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "esp_log.h"
+#include "esp_err.h"
+#include "driver/gpio.h"
+//#include "esp_timer.h"  note: don't call system_restart() from a esp_timer callback see https://esp32.com/viewtopic.php?f=13&t=9542
+#include "freertos/FreeRTOS.h"
+#include "freertos/timers.h" // use a FreeRTOS timer instead
+#include "esp_system.h"  // for system_restart();
+#include "io.h"
 
-#include <libesphttpd/esp.h>
+// these for erase partition:
+#include "esp_ota_ops.h"
+#include "esp_flash_data_types.h"
+#include "esp_image_format.h"
 
-#define LEDGPIO 2
-#define BTNGPIO 0
+static const char* TAG = "io.c";
+#define RST_BTN_SAMPLE_MS	(100) //ms
 
-#ifndef ESP32
-static os_timer_t resetBtntimer;
-#endif
-
-void ioLed(int ena) {
-#ifndef ESP32
-	//gpio_output_set is overkill. ToDo: use better mactos
-	if (ena) {
-		gpio_output_set((1<<LEDGPIO), 0, (1<<LEDGPIO), 0);
-	} else {
-		gpio_output_set(0, (1<<LEDGPIO), (1<<LEDGPIO), 0);
-	}
-#endif
+static enum BLE_state_e ble_state = BLE_STATE_OFF;
+void set_status_ind_ble(enum BLE_state_e new_state){
+	if (new_state < BLE_STATE_NUM_STATES) ble_state = new_state;
+}
+static enum WIFI_state_e wifi_state = WIFI_STATE_OFF;
+void set_status_ind_wifi(enum WIFI_state_e new_state){
+	if (new_state < WIFI_STATE_NUM_STATES) wifi_state = new_state;
 }
 
-#ifndef ESP32
+void ioLed(int ledgpio, int en) {
+	int level = (en)?1:0;
+
+	gpio_set_level(ledgpio, level);
+}
+
+#define SM_INIT	(1)
+#define SM_NO_INIT	(0)
+
+/**
+ * @brief   TTP_config-blink State Machine
+ *
+ */
+static void blink_stateMachine(int init, uint32_t delta_time, int num1, int num2) {
+	// State names for the Blink_stateMachine
+	static enum {
+		BLINK_STATE_INIT,
+		BLINK_STATE_PAUSE_START,
+		BLINK_STATE_N1_BLINK_ON,
+		BLINK_STATE_N1_BLINK_OFF,
+		BLINK_STATE_PAUSE_MID,
+		BLINK_STATE_N2_BLINK_ON,
+		BLINK_STATE_N2_BLINK_OFF,
+		BLINK_STATE_PAUSE_END,
+	}blink_state;
+
+#define BLINK_tSTART (500)  // beginning off-time
+#define BLINK_tNh    (250)  // num1 blink on-time
+#define BLINK_tNl    (250)  // num1 blink off-time
+#define BLINK_tMID   (0 + BLINK_tNl)  // middle off-time
+#define BLINK_tN2h  (350)  // num2 blink on-time
+#define BLINK_tN2l  (150)  // num2 blink off-time
+#define BLINK_tEND   (500 + BLINK_tN2l)  // End off-time
+	static int32_t t = 0;    // local timer
+	static uint8_t myN = 0;  // local counter
+	t += delta_time;
+	if (init == SM_INIT) blink_state = BLINK_STATE_INIT;
+
+	switch (blink_state){
+	case BLINK_STATE_INIT:
+		blink_state = BLINK_STATE_PAUSE_START;
+		ioLed(LED_WIFI, 0);  // Turn off LED1
+		ioLed(LED_BLE, 0);  // Turn off LED2
+		t = 0;
+		break;
+	case BLINK_STATE_PAUSE_START:
+		if (num1 == 0) blink_state = BLINK_STATE_PAUSE_MID;
+		else if (t >= BLINK_tSTART) {
+			t -= BLINK_tSTART;
+			blink_state = BLINK_STATE_N1_BLINK_ON;
+			ioLed(LED_WIFI, 1);  // Turn ON LED1
+			myN = 0;
+		}
+		break;
+	case BLINK_STATE_N1_BLINK_ON:
+		if (t >= BLINK_tNh) {
+			t -= BLINK_tNh;
+			blink_state = BLINK_STATE_N1_BLINK_OFF;
+			ioLed(LED_WIFI, 0); // Turn OFF LED1
+			myN += 1;
+			//ESP_LOGI(TAG, "BLINK_STATE_N1_BLINK_OFF: myN: %i", myN);
+		}
+		break;
+	case BLINK_STATE_N1_BLINK_OFF:
+		if (myN >= num1) {
+			blink_state = BLINK_STATE_PAUSE_MID;
+			//LED_pattern_init(0, palette[C_OFF]); // Turn OFF
+			//t = 0;
+		}
+		else if (t >= BLINK_tNl) {
+			t -= BLINK_tNl;
+			blink_state = BLINK_STATE_N1_BLINK_ON;
+			ioLed(LED_WIFI, 1);  // Turn ON LED1
+		}
+		break;
+	case BLINK_STATE_PAUSE_MID:
+		if (num2 == 0) blink_state = BLINK_STATE_PAUSE_END;
+		if (t >= BLINK_tMID) {
+			t -= BLINK_tMID;
+			blink_state = BLINK_STATE_N2_BLINK_ON;
+			ioLed(LED_BLE, 1); // Turn ON LED2
+			myN = 0;
+		}
+		break;
+	case BLINK_STATE_N2_BLINK_ON:
+		if (t >= BLINK_tN2h) {
+			t -= BLINK_tN2h;
+			blink_state = BLINK_STATE_N2_BLINK_OFF;
+			ioLed(LED_BLE, 0); // Turn OFF LED2
+			myN += 1;
+			//ESP_LOGI(TAG, "BLINK_STATE_N2_BLINK_OFF: myN: %i", myN);
+		}
+		break;
+	case BLINK_STATE_N2_BLINK_OFF:
+		if (myN >= num2){
+			blink_state = BLINK_STATE_PAUSE_END;
+			//LED_pattern_init(0, palette[C_OFF]); // Turn OFF
+			//t = 0;
+		}
+		else if (t >= BLINK_tN2l){
+			t -= BLINK_tN2l;
+			blink_state = BLINK_STATE_N2_BLINK_ON;
+			ioLed(LED_BLE, 1); // Turn ON LED2
+
+		}
+		break;
+	case BLINK_STATE_PAUSE_END:
+		if (t >= BLINK_tEND){
+			t -= BLINK_tEND;
+			blink_state = BLINK_STATE_PAUSE_START;
+		}
+		break;
+	default:
+		break;
+	}
+	/** Use plantuml.com or PlantUML Eclipse-plugin to render this state-machine-diagram:
+
+@startuml
+title State Machine Diagram for Blink
+[*] --> INIT : Reset
+INIT --> PAUSE_START : [set t=0]
+PAUSE_START --> N1_BLINK_ON : t > tSTART\n[set t=0]
+N1_BLINK_ON -d-> N1_BLINK_OFF : t > tN_on\n[set t=0]\n[set myN+=1]
+N1_BLINK_OFF --> N1_BLINK_ON : t > tN_on\n[set t=0]
+N1_BLINK_OFF --> PAUSE_MID : myN >= num1\n[set t=0]
+PAUSE_MID --> N2_BLINK_ON : t > tMID\n[set t=0]
+N2_BLINK_ON -d-> N2_BLINK_OFF : t > tN2h\n[set t=0]\n[set myN+=1]
+N2_BLINK_OFF --> N2_BLINK_ON : t > tN2l\n[set t=0]
+N2_BLINK_OFF --> PAUSE_END : myN >= num2\n[set t=0]
+PAUSE_END --> INIT : t > tEND
+@enduml
+
+	 */
+}
+
 static void resetBtnTimerCb(void *arg) {
 	static int resetCnt=0;
-	if ((GPIO_REG_READ(GPIO_IN_ADDRESS)&(1<<BTNGPIO))==0) {
+	if (gpio_get_level(BTN_GPIO)==0) {
+		// button is depressed
 		resetCnt++;
+		if (resetCnt>=3000/RST_BTN_SAMPLE_MS) { //>3 sec pressed
+			// Blink like crazy to indicate that button has been pressed long-enough.
+			blink_stateMachine(SM_NO_INIT, 50*RST_BTN_SAMPLE_MS, 1, 1);
+		} else {
+			// Force LEDs off while button is depressed <3s.
+			ioLed(LED_WIFI, 0); // Turn OFF LED1
+			ioLed(LED_BLE, 0); // Turn OFF LED2
+		}
 	} else {
-		if (resetCnt>=6) { //3 sec pressed
-			wifi_station_disconnect();
-			wifi_set_opmode(0x3); //reset to AP+STA mode
-			printf("Reset to AP mode. Restarting system...\n");
-			system_restart();
+		// button not pressed
+
+		// Button was released after 3s pressed.  Reset networking settings.
+		if (resetCnt>=3000/RST_BTN_SAMPLE_MS) {
+			const esp_partition_t *wanted_partition = NULL;
+			esp_err_t err = ESP_FAIL;
+			printf("Reset WiFi and Bluetooth settings.\n");
+			ESP_LOGI(TAG, "Erase NVS command!");
+			wanted_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA,ESP_PARTITION_SUBTYPE_ANY,"nvs");
+			err = esp_partition_erase_range(wanted_partition, 0, wanted_partition->size);
+			if (err != ESP_OK) {
+				ESP_LOGE(TAG, "erase partition failed! err=0x%x", err);
+			}
+			else
+			{
+				ESP_LOGW(TAG, "NVS partition is erased now!  Must reboot to reformat it!");
+			}
+			ioLed(LED_WIFI, 1); // Turn ON LED1
+			ioLed(LED_BLE, 1); // Turn ON LED2
+
+			printf("Restarting system...\n");
+			esp_restart();  // note: don't call this from a esp_timer callback use a FreeRTOS timer instead see https://esp32.com/viewtopic.php?f=13&t=9542
+
+			// Button was released before 3s, restart
+		} else if (resetCnt >= 1) {
+			ioLed(LED_WIFI, 1); // Turn ON LED1
+			ioLed(LED_BLE, 1); // Turn ON LED2
+
+			printf("Restarting system...\n");
+			esp_restart();  // note: don't call this from a esp_timer callback use a FreeRTOS timer instead see https://esp32.com/viewtopic.php?f=13&t=9542
 		}
 		resetCnt=0;
+
+		blink_stateMachine(SM_NO_INIT, RST_BTN_SAMPLE_MS, wifi_state, ble_state);  // BLE state blinks blue LED, WiFi state blinks green LED.
 	}
 }
-#endif
-
 
 void ioInit() {
-#ifndef ESP32
-	PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO2_U, FUNC_GPIO2);
-	PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0);
-	gpio_output_set(0, 0, (1<<LEDGPIO), (1<<BTNGPIO));
-	os_timer_disarm(&resetBtntimer);
-	os_timer_setfn(&resetBtntimer, resetBtnTimerCb, NULL);
-	os_timer_arm(&resetBtntimer, 500, 1);
-#endif
+	ioLed(LED_WIFI, 0);  // Turn off LED1
+	ioLed(LED_BLE, 0);  // Turn off LED2
+
+	/* Configure the IOMUX register for pad GPIO */
+	gpio_pad_select_gpio(LED_WIFI);
+	gpio_pad_select_gpio(LED_BLE);
+	gpio_pad_select_gpio(LED_CGI);
+	gpio_pad_select_gpio(BTN_GPIO);
+	/* Set the GPIO as a push/pull output */
+	gpio_set_direction(LED_WIFI, GPIO_MODE_INPUT_OUTPUT);
+	gpio_set_direction(LED_BLE, GPIO_MODE_INPUT_OUTPUT);
+	gpio_set_direction(LED_CGI, GPIO_MODE_INPUT_OUTPUT);
+	gpio_set_direction(BTN_GPIO, GPIO_MODE_INPUT);
+
+	blink_stateMachine(SM_INIT, 0,0,0);  // Init blink_stateMachine
+
+	/* Create a periodic timer which will run every 0.1s */
+	TimerHandle_t resetBtnTimer = xTimerCreate(    "rstTmr",       // Just a text name, not used by the kernel.
+			( RST_BTN_SAMPLE_MS / portTICK_RATE_MS ),   // The timer period in ticks.
+			pdTRUE,        // The timers will auto-reload themselves when they expire.
+			0,  // Assign each timer a unique id equal to its array index.
+			resetBtnTimerCb // Each timer calls the same callback when it expires.
+	);
+	/* The timer has been created but is not running yet */
+
+	/* Start the timers */
+	xTimerStart( resetBtnTimer, 0 );
+	ESP_LOGI(TAG, "Started resetBtn timer");
 }
 

--- a/main/io.h
+++ b/main/io.h
@@ -1,7 +1,34 @@
 #ifndef IO_H
 #define IO_H
 
-void ICACHE_FLASH_ATTR ioLed(int ena);
+#include "driver/gpio.h"
+
+#define LED_WIFI (GPIO_NUM_5)  // Green LED
+#define LED_BLE (GPIO_NUM_15) // Blue LED
+#define LED_CGI (GPIO_NUM_32)  // Red LED
+
+enum BLE_state_e {
+	BLE_STATE_OFF = 0,  // BLE turned-off
+	BLE_STATE_ADV = 1,  // BLE is advertising but not connected
+	BLE_STATE_CONN = 2, // BLE connected to a central
+	BLE_STATE_FAIL,
+	BLE_STATE_NUM_STATES
+};
+void set_status_ind_ble(enum BLE_state_e new_state);
+
+enum WIFI_state_e {
+	WIFI_STATE_OFF = 0,  // either off or set to STA but not connected
+	WIFI_STATE_AP = 1,   // AP enabled but no clients connected
+	WIFI_STATE_CONN = 2, // WiFi connected to 1+ peer either as AP or STA
+	WIFI_STATE_FAIL,
+	WIFI_STATE_NUM_STATES
+};
+void set_status_ind_wifi(enum WIFI_state_e new_state);
+
+#define BTN_GPIO  (GPIO_NUM_34) // Push-button
+
+
+void ioLed(int ledgpio, int en);
 void ioInit(void);
 
 #endif


### PR DESCRIPTION
- Fix resetBtn didn't reset on ESP32.   See https://esp32.com/viewtopic.php?t=9542
- Hold resetBtn >6s wipes NVS partition to clear WiFi settings.
- Add blinky light to show WiFi status, using same timer callback as resetBtn.
- Misc fixes an improvements.
