### PR TITLE
Added Ethernet capability

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -3,12 +3,116 @@ menu "Example Configuration"
 		string "WiFi SSID"
 		default "myssid"
 		help
-		SSID (network name) for the example to connect to.
+			SSID (network name) for the example to connect to.
 
 	config EXAMPLE_WIFI_PASSWORD
 		string "WiFi Password"
 		default "mypassword"
 		help
-		WiFi password (WPA or WPA2) for the example to use.
+			WiFi password (WPA or WPA2) for the example to use.
 
+    config EXAMPLE_USE_ETHERNET
+        bool "Enable Ethernet"
+        default n
+        help
+			Use Ethernet driver in this example.  See other component section for Ethernet configuration.  
+			
+	menu "Ethernet PHY Configuration"
+	depends on EXAMPLE_USE_ETHERNET
+	choice PHY_MODEL
+		prompt "Ethernet PHY"
+		default PHY_LAN8720
+		help
+			Select the PHY driver to use for the example.
+
+	config PHY_TLK110
+		bool "TLK110 PHY"
+		help
+			Select this to use the TI TLK110 PHY
+
+	config PHY_LAN8720
+		bool "LAN8720 PHY"
+		help
+			Select this to use the Microchip LAN8720 PHY
+
+	endchoice
+
+
+	config PHY_ADDRESS
+		int "PHY Address (0-31)"
+		default 0
+		range 0 31
+		help
+			Select the PHY Address (0-31) for the hardware configuration and PHY model.
+			TLK110 default 31
+			LAN8720 default 1 or 0
+
+
+	choice PHY_CLOCK_MODE
+		prompt "EMAC clock mode"
+		default PHY_CLOCK_GPIO0_IN
+		help
+			Select external (input on GPIO0) or internal (output on GPIO0, GPIO16 or GPIO17) clock
+
+
+	config PHY_CLOCK_GPIO0_IN
+		bool "GPIO0 input"
+		help
+			Input of 50MHz refclock on GPIO0
+
+	config PHY_CLOCK_GPIO0_OUT
+		bool "GPIO0 output"
+		help
+			Output the internal 50MHz APLL clock on GPIO0
+
+	config PHY_CLOCK_GPIO16_OUT
+		bool "GPIO16 output"
+		help
+			Output the internal 50MHz APLL clock on GPIO16
+
+	config PHY_CLOCK_GPIO17_OUT
+		bool "GPIO17 output (inverted)"
+		help
+			Output the internal 50MHz APLL clock on GPIO17 (inverted signal)
+
+	endchoice
+
+	config PHY_CLOCK_MODE
+		int
+		default 0 if PHY_CLOCK_GPIO0_IN
+		default 1 if PHY_CLOCK_GPIO0_OUT
+		default 2 if PHY_CLOCK_GPIO16_OUT
+		default 3 if PHY_CLOCK_GPIO17_OUT
+
+
+	config PHY_USE_POWER_PIN
+		bool "Use PHY Power (enable/disable) pin"
+		default n
+		help
+			Use a GPIO "power pin" to power the PHY on/off during operation.
+			Consult the example README for more details
+
+	config PHY_POWER_PIN
+		int "PHY Power GPIO"
+		default 17
+		range 0 33
+		depends on PHY_USE_POWER_PIN
+		help
+			GPIO number to use for powering on/off the PHY.
+
+	config PHY_SMI_MDC_PIN
+		int "SMI MDC Pin"
+		default 23
+		range 0 33
+		help
+			GPIO number to use for SMI clock output MDC to PHY.
+
+	config PHY_SMI_MDIO_PIN
+		int "SMI MDIO Pin"
+		default 18
+		range 0 33
+		help
+		GPIO number to use for SMI data pin MDIO to/from PHY.
+
+	endmenu
 endmenu

--- a/main/ethernet_init.c
+++ b/main/ethernet_init.c
@@ -1,0 +1,163 @@
+/* ethernet Example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <stdio.h>
+#include <string.h>
+#include "sdkconfig.h"
+
+#ifdef CONFIG_PHY_LAN8720
+#define ETHERNET_ENABLE 1
+#include "eth_phy/phy_lan8720.h"
+#define DEFAULT_ETHERNET_PHY_CONFIG phy_lan8720_default_ethernet_config
+#elif defined CONFIG_PHY_TLK110
+#define ETHERNET_ENABLE 1
+#include "eth_phy/phy_tlk110.h"
+#define DEFAULT_ETHERNET_PHY_CONFIG phy_tlk110_default_ethernet_config
+#elif defined CONFIG_EXAMPLE_USE_ETHERNET && CONFIG_EXAMPLE_USE_ETHERNET
+#warning "Must define Ethernet PHY type in menuconfig"
+#endif
+
+#ifdef ETHERNET_ENABLE
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "esp_system.h"
+#include "esp_err.h"
+#include "esp_event_loop.h"
+#include "esp_event.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+#include "esp_eth.h"
+
+#include "rom/ets_sys.h"
+#include "rom/gpio.h"
+
+#include "soc/dport_reg.h"
+#include "soc/io_mux_reg.h"
+#include "soc/rtc_cntl_reg.h"
+#include "soc/gpio_reg.h"
+#include "soc/gpio_sig_map.h"
+
+#include "tcpip_adapter.h"
+#include "nvs_flash.h"
+#include "driver/gpio.h"
+
+#include "soc/emac_ex_reg.h"
+#include "driver/periph_ctrl.h"
+
+
+//static const char *TAG = "ethernet_init.c";
+
+#define PIN_PHY_POWER CONFIG_PHY_POWER_PIN
+#define PIN_SMI_MDC   CONFIG_PHY_SMI_MDC_PIN
+#define PIN_SMI_MDIO  CONFIG_PHY_SMI_MDIO_PIN
+
+#ifdef CONFIG_PHY_USE_POWER_PIN
+/* This replaces the default PHY power on/off function with one that
+   also uses a GPIO for power on/off.
+
+   If this GPIO is not connected on your device (and PHY is always powered), you can use the default PHY-specific power
+   on/off function rather than overriding with this one.
+*/
+static void phy_device_power_enable_via_gpio(bool enable)
+{
+    assert(DEFAULT_ETHERNET_PHY_CONFIG.phy_power_enable);
+
+    if (!enable) {
+        /* Do the PHY-specific power_enable(false) function before powering down */
+        DEFAULT_ETHERNET_PHY_CONFIG.phy_power_enable(false);
+    }
+
+    gpio_pad_select_gpio(PIN_PHY_POWER);
+    gpio_set_direction(PIN_PHY_POWER,GPIO_MODE_OUTPUT);
+    if(enable == true) {
+        gpio_set_level(PIN_PHY_POWER, 1);
+        ESP_LOGD(TAG, "phy_device_power_enable(TRUE)");
+    } else {
+        gpio_set_level(PIN_PHY_POWER, 0);
+        ESP_LOGD(TAG, "power_enable(FALSE)");
+    }
+
+    // Allow the power up/down to take effect, min 300us
+    vTaskDelay(1);
+
+    if (enable) {
+        /* Run the PHY-specific power on operations now the PHY has power */
+        DEFAULT_ETHERNET_PHY_CONFIG.phy_power_enable(true);
+    }
+}
+#endif
+
+static void eth_gpio_config_rmii(void)
+{
+    // RMII data pins are fixed:
+    // TXD0 = GPIO19
+    // TXD1 = GPIO22
+    // TX_EN = GPIO21
+    // RXD0 = GPIO25
+    // RXD1 = GPIO26
+    // CLK == GPIO0
+    phy_rmii_configure_data_interface_pins();
+    // MDC and MDIO are configurable from menuconfig
+    phy_rmii_smi_configure_pins(PIN_SMI_MDC, PIN_SMI_MDIO);
+}
+
+esp_err_t ethernet_handle_system_event(void *ctx, system_event_t *event){
+
+    switch(event->event_id) {
+		case SYSTEM_EVENT_ETH_GOT_IP:
+		{ // need bracket to declare var
+			tcpip_adapter_ip_info_t ap_ip_info;
+			memset(&ap_ip_info, 0, sizeof(tcpip_adapter_ip_info_t)); // clear to all zero (needed?)
+			if (tcpip_adapter_get_ip_info(ESP_IF_ETH, &ap_ip_info) == 0) {
+				printf("~~~~~ETH~~~~~~" "\n");
+				printf("IP:" IPSTR "\n", IP2STR(&ap_ip_info.ip));
+				printf("MASK:" IPSTR "\n", IP2STR(&ap_ip_info.netmask));
+				printf("GW:" IPSTR "\n", IP2STR(&ap_ip_info.gw));
+				printf("~~~~~~~~~~~~~~" "\n");
+			}
+		}
+			break;
+
+		default:
+			break;
+    }
+
+    return ESP_OK;
+}
+
+void init_ethernet()
+{
+    esp_err_t ret = ESP_OK;
+    //tcpip_adapter_init(); - done in main.c
+    //esp_event_loop_init(NULL, NULL); - done in main.c
+
+    eth_config_t config = DEFAULT_ETHERNET_PHY_CONFIG;
+    /* Set the PHY address in the example configuration */
+    config.phy_addr = CONFIG_PHY_ADDRESS;
+    config.gpio_config = eth_gpio_config_rmii;
+    config.tcpip_input = tcpip_adapter_eth_input;
+    config.clock_mode = CONFIG_PHY_CLOCK_MODE;
+
+#ifdef CONFIG_PHY_USE_POWER_PIN
+    /* Replace the default 'power enable' function with an example-specific
+       one that toggles a power GPIO. */
+    config.phy_power_enable = phy_device_power_enable_via_gpio;
+#endif
+
+    ret = esp_eth_init(&config);
+
+    if(ret == ESP_OK) {
+        ret = esp_eth_enable();
+        if(ret == ESP_OK) {
+        	//xTaskCreate(eth_task, "eth_task", 2048, NULL, (tskIDLE_PRIORITY + 2), NULL);
+        }
+    }
+
+}
+#endif

--- a/main/ethernet_init.h
+++ b/main/ethernet_init.h
@@ -1,0 +1,20 @@
+/*
+ * ethernet_init.h
+ */
+
+#ifndef MAIN_ETHERNET_INIT_H_
+#define MAIN_ETHERNET_INIT_H_
+
+void init_ethernet(void);
+
+/**
+ * @brief   System event handler
+ *          This method controls the service state on all active interfaces and applications are required
+ *          to call it from the system event handler for normal operation of mDNS service.
+ *
+ * @param  ctx          The system event context
+ * @param  event        The system event
+ */
+esp_err_t ethernet_handle_system_event(void *ctx, system_event_t *event);
+
+#endif /* MAIN_ETHERNET_INIT_H_ */


### PR DESCRIPTION
Added Ethernet capability, disabled by default.  Enable via menuconfig->Example Configuration->Enable Ethernet.  The default PHY options work with Olimex ESP32-EVB and probably most other ESP32 dev boards with Ethernet.